### PR TITLE
Fixed compile error on macOS

### DIFF
--- a/src/libsnore/plugins/plugincontainer.cpp
+++ b/src/libsnore/plugins/plugincontainer.cpp
@@ -154,7 +154,6 @@ const QDir &PluginContainer::pluginDir()
         QString appDir = qApp->applicationDirPath();
 #ifdef Q_OS_MAC
         if (appDir == QLatin1String("MacOS")) {
-            list << appDir;
             QDir dir(appDir);
             // Development convenience-hack
             dir.cdUp();


### PR DESCRIPTION
While trying to build snorenotify on macOS, I've found out that the version 0.7.0 does not compile out of the box because it contains deprecated 'not' Objective-C keyword.

Then I decided to take the HEAD revision and all compiled fine except by the little error fixed in this pull-request.